### PR TITLE
Add libkrw/libkernrw dependency for iOS 14+

### DIFF
--- a/control
+++ b/control
@@ -2,6 +2,7 @@ Package: kr.xsf1re.vnodebypass
 Name: vnodebypass
 Version: 0.2.3
 Architecture: iphoneos-arm
+Depends: firmware (<< 14.0) | libkrw | org.coolstar.libkernrw
 Description: An expermental tool to hide jailbreak files for bypass detection.
 Maintainer: XsF1re
 Author: XsF1re


### PR DESCRIPTION
Technically not required on checkra1n, but this cannot be detected via the control file (as even A11- users could be using unc0ver or Taurine), but it won't hurt them to install a small library anyway.